### PR TITLE
Add dbsearch as a default plugin.

### DIFF
--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -226,6 +226,9 @@ exports.webpack = async function (options) {
     if (!activePlugins.includes('nodebb-plugin-composer-default')) {
         activePlugins.push('nodebb-plugin-composer-default');
     }
+    if (!activePlugins.includes('nodebb-plugin-dbsearch')) {
+        activePlugins.push('nodebb-plugin-dbsearch');
+    }
     await fs.promises.writeFile(path.resolve(__dirname, '../../build/active_plugins.json'), JSON.stringify(activePlugins));
 
     const webpackCfg = getWebpackConfig();


### PR DESCRIPTION
Sets up dbsearch as a default plugin for nodebb on build.

This is useful (if it works!) because it gets us a well-tested search page and some search infrastructure by default.