### PR TITLE
Backend topics tool to toggle the database resolved field

### DIFF
--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -31,6 +31,14 @@ Events._types = {
         icon: 'fa-thumb-tack',
         text: '[[topic:unpinned-by]]',
     },
+    // resolve: {
+    //     icon: '',
+    //     text: '[[topic:resolved-by]]',
+    // },
+    // unresolve: {
+    //     icon: '',
+    //     text: '[[topic:unresolved-by]]',
+    // },
     lock: {
         icon: 'fa-lock',
         text: '[[topic:locked-by]]',

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -149,6 +149,39 @@ module.exports = function (Topics) {
         return tids.filter(Boolean);
     };
 
+    topicTools.resolve = async function (tid, uid) {
+        return await toggleResolve(tid, uid, true);
+    };
+
+    topicTools.unresolve = async function (tid, uid) {
+        return await toggleResolve(tid, uid, false);
+    };
+
+    async function toggleResolve(tid, uid, res){
+        const topicData = await Topics.getTopicData(tid);
+        if (!topicData) {
+            throw new Error('[[error:no-topic]]');
+        }
+
+        const promises = [
+            Topics.setTopicField(tid, 'resolved', res ? 1 : 0),
+            // Topics.events.log(tid, { type: res ? 'resolve' : 'unresolve', uid }),
+        ];
+
+        if (res) {
+            promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:resolved`, Date.now(), tid));
+        }
+        else{
+            promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:resolved`, tid));
+        }
+
+        const results = await Promise.all(promises);
+        topicData.resolved = res
+        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid });
+
+        return topicData;
+    };
+
     async function togglePin(tid, uid, pin) {
         const topicData = await Topics.getTopicData(tid);
         if (!topicData) {
@@ -292,4 +325,6 @@ module.exports = function (Topics) {
 
         plugins.hooks.fire('action:topic.move', hookData);
     };
+
+
 };


### PR DESCRIPTION
Added functionality to topics to interact with the database and toggle the resolved status of a topic. Still need to implement event logging, but that could be something down the line. Have not fully tested this yet - I am unsure if updates will actually occur to the database, or if I need to register a new action hook. Need to merge with database changes to fully test this.

Addresses issue #11 