### PR TITLE
Handle resolving posts

### DIFF
--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -182,6 +182,14 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
         Topics.events.get(topicData.tid, uid, reverse),
     ]);
 
+    let hasResolution = false;
+    posts.forEach((p) => {
+        if (p.content.toLowerCase().includes("resolved")) {
+            hasResolution = true;
+        }
+    });
+    posts[0].resolved = hasResolution;
+    topicData.hasResolution = hasResolution;
     topicData.thumbs = thumbs[0];
     topicData.posts = posts;
     topicData.events = events;

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -79,6 +79,9 @@
     <small class="pull-right">
         <!-- IMPORT partials/topic/reactions.tpl -->
         <span class="post-tools">
+            {{{ if posts.resolved }}}
+            Resolved
+            {{{ end }}}
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
         </span>


### PR DESCRIPTION
Allow users to resolve posts by replying "resolved" to said posts. Fairly invasive change, that works by looking at the text of every post, but it should have low performance overhead and is much simpler than writing hooks and plugins.

Joint work with @Noor-5 @ruiminggu: this is based on #19 and #20, though work is still ongoing on the latter.

Fixes #11.