### PR TITLE
Built MVP backend functionality for resolving and unresolving posts

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -129,6 +129,14 @@ topicsAPI.unpin = async function (caller, data) {
     });
 };
 
+topicsAPI.resolve = async function (caller, data) {
+    await doTopicAction('resolve', 'event:topic_resolved', caller, {tids:data.tid,});
+};
+
+topicsAPI.unresolve = async function (caller,data){
+    await doTopicAction('unresolve', 'event:topic_unresolved', caller, {tids:data.tid});
+};
+
 topicsAPI.lock = async function (caller, data) {
     await doTopicAction('lock', 'event:topic_locked', caller, {
         tids: data.tids,

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -81,6 +81,16 @@ Topics.unpin = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
+Topics.resolve = async (req, res) => {
+    await api.topics.resolve(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.unresolve = async (req, res) => {
+    await api.topics.unresolve(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
 Topics.lock = async (req, res) => {
     await api.topics.lock(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,6 +24,9 @@ module.exports = function () {
     setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
     setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
 
+    setupApiRoute(router, 'put', '/:tid/resolve', [...middlewares, middleware.assert.topic], controllers.write.topics.resolve);
+    setupApiRoute(router, 'delete', '/:tid/resolve', [...middlewares, middleware.assert.topic], controllers.write.topics.unresolve);
+
     setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
     setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            resolved: false,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
@@ -234,6 +235,7 @@ module.exports = function (Topics) {
 
         postData.votes = 0;
         postData.bookmarked = false;
+        postData.resolved = false;
         postData.display_edit_tools = true;
         postData.display_delete_tools = true;
         postData.display_moderator_tools = true;

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -31,6 +31,14 @@ Events._types = {
         icon: 'fa-thumb-tack',
         text: '[[topic:unpinned-by]]',
     },
+    // resolve: {
+    //     icon: '',
+    //     text: '[[topic:resolved-by]]',
+    // },
+    // unresolve: {
+    //     icon: '',
+    //     text: '[[topic:unresolved-by]]',
+    // },
     lock: {
         icon: 'fa-lock',
         text: '[[topic:locked-by]]',

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -157,7 +157,7 @@ module.exports = function (Topics) {
         return await toggleResolve(tid, uid, false);
     };
 
-    async function toggleResolve(tid, uid, res){
+    async function toggleResolve(tid, uid, res) {
         const topicData = await Topics.getTopicData(tid);
         if (!topicData) {
             throw new Error('[[error:no-topic]]');
@@ -170,17 +170,17 @@ module.exports = function (Topics) {
 
         if (res) {
             promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:resolved`, Date.now(), tid));
-        }
-        else{
+        } else {
             promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:resolved`, tid));
         }
 
         const results = await Promise.all(promises);
-        topicData.resolved = res
+        topicData.events = results[1];
+        topicData.resolved = res;
         plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid });
 
         return topicData;
-    };
+    }
 
     async function togglePin(tid, uid, pin) {
         const topicData = await Topics.getTopicData(tid);
@@ -325,6 +325,4 @@ module.exports = function (Topics) {
 
         plugins.hooks.fire('action:topic.move', hookData);
     };
-
-
 };

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -149,6 +149,39 @@ module.exports = function (Topics) {
         return tids.filter(Boolean);
     };
 
+    topicTools.resolve = async function (tid, uid) {
+        return await toggleResolve(tid, uid, true);
+    };
+
+    topicTools.unresolve = async function (tid, uid) {
+        return await toggleResolve(tid, uid, false);
+    };
+
+    async function toggleResolve(tid, uid, res){
+        const topicData = await Topics.getTopicData(tid);
+        if (!topicData) {
+            throw new Error('[[error:no-topic]]');
+        }
+
+        const promises = [
+            Topics.setTopicField(tid, 'resolved', res ? 1 : 0),
+            // Topics.events.log(tid, { type: res ? 'resolve' : 'unresolve', uid }),
+        ];
+
+        if (res) {
+            promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:resolved`, Date.now(), tid));
+        }
+        else{
+            promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:resolved`, tid));
+        }
+
+        const results = await Promise.all(promises);
+        topicData.resolved = res
+        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid });
+
+        return topicData;
+    };
+
     async function togglePin(tid, uid, pin) {
         const topicData = await Topics.getTopicData(tid);
         if (!topicData) {
@@ -292,4 +325,6 @@ module.exports = function (Topics) {
 
         plugins.hooks.fire('action:topic.move', hookData);
     };
+
+
 };

--- a/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
@@ -13,6 +13,8 @@
 
     <!-- IMPORT partials/topic/sort.tpl -->
 
+    <!-- IMPORT partials/topic/resolve.tpl -->
+
     <div class="inline-block">
     <!-- IMPORT partials/thread_tools.tpl -->
     </div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/resolve.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/resolve.tpl
@@ -1,0 +1,15 @@
+<div title="[[topic:resolve]]" class="btn-group bottom-sheet hidden-xs" component="topic/resolve">
+    <label class="btn btn-sm btn-default">
+      <input type="radio" name="resolveRadio" class="hidden" autocomplete="off">
+      <span><i class="fa fa-fw fa-sort"></i></span>
+    </label>
+    <ul class="radio">
+      <li>
+        <label class="btn">
+          <input type="radio" name="resolveRadio" class="hidden" autocomplete="off">
+          <i class="fa fa-fw"></i>
+          [[topic.resolved ? 'Unresolved' : 'Resolve']]
+        </label>
+      </li>
+    </ul>
+  </div>


### PR DESCRIPTION
Created module functions for topics that toggle the resolved status of a topic in the backend. Added API functions that are called by an endpoint to update the resolved status. These have new put and delete routes associated with them. I also created the controllers that these routes use. Finally, I started implementing the front end button that interacts with the backend, but without much success. Might need some help from @ruiminggu  on that, and will also need to read the UI documentation in more depth.

Progress on issues #11, #12, #13, #16, and #17
